### PR TITLE
[rpc] [p2p] [zmq] [docs] Set P2P and RPC ports to BTCP values

### DIFF
--- a/contrib/debian/examples/bitcoin.conf
+++ b/contrib/debian/examples/bitcoin.conf
@@ -44,11 +44,11 @@
 
 # Use as many addnode= settings as you like to connect to specific peers
 #addnode=69.164.218.197
-#addnode=10.0.0.2:8333
+#addnode=10.0.0.2:7933
 
 # Alternatively use as many connect= settings as you like to connect ONLY to specific peers
 #connect=69.164.218.197
-#connect=10.0.0.1:8333
+#connect=10.0.0.1:7933
 
 # Listening mode, enabled by default except when 'connect' is being used
 #listen=1
@@ -110,7 +110,7 @@
 #rpcallowip=2001:db8:85a3:0:0:8a2e:370:7334/96
 
 # Listen for RPC connections on this TCP port:
-#rpcport=8332
+#rpcport=7932
 
 # You can use Bitcoin or bitcoind to send commands to Bitcoin/bitcoind
 # running on another host using this option:

--- a/contrib/linearize/README.md
+++ b/contrib/linearize/README.md
@@ -12,7 +12,7 @@ Required configuration file settings for linearize-hashes:
 
 Optional config file setting for linearize-hashes:
 * RPC: `host`  (Default: `127.0.0.1`)
-* RPC: `port`  (Default: `8332`)
+* RPC: `port`  (Default: `7932`)
 * Blockchain: `min_height`, `max_height`
 * `rev_hash_bytes`: If true, the written block hash list will be
 byte-reversed. (In other words, the hash returned by getblockhash will have its

--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -1,17 +1,17 @@
-# bitcoind RPC settings (linearize-hashes)
+# bitcoind RPC settings (linearize-hashes) (modified for Bitcoin Private)
 rpcuser=someuser
 rpcpassword=somepassword
-#datadir=~/.bitcoin
+#datadir=~/.btcp
 host=127.0.0.1
 
 #mainnet default
-port=8332
+port=7932
 
 #testnet default
-#port=18332
+#port=17932
 
 #regtest default
-#port=18443
+#port=17443
 
 # bootstrap.dat hashlist settings (linearize-hashes)
 max_height=313000
@@ -19,14 +19,14 @@ max_height=313000
 # bootstrap.dat input/output settings (linearize-data)
 
 # mainnet
-netmagic=f9beb4d9
-genesis=000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
-input=/home/example/.bitcoin/blocks
+netmagic=a8eaa2cd
+genesis=0007104ccda289427919efc39dc9e4d499804b7bebc22df55f8b834301260602
+input=/home/example/.btcp/blocks
 
 # testnet
-#netmagic=0b110907
-#genesis=000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943
-#input=/home/example/.bitcoin/testnet3/blocks
+#netmagic=f61bf6d6
+#genesis=03e1c4bb705c871bf9bfda3e74b7f8f86bff267993c215a89d5795e3708e5e1f
+#input=/home/example/.btcp/testnet/blocks
 
 # "output" option causes blockchain files to be written to the given location,
 # with "output_file" ignored. If not used, "output_file" is used instead.

--- a/contrib/linearize/linearize-hashes.py
+++ b/contrib/linearize/linearize-hashes.py
@@ -124,7 +124,7 @@ if __name__ == '__main__':
     if 'host' not in settings:
         settings['host'] = '127.0.0.1'
     if 'port' not in settings:
-        settings['port'] = 8332
+        settings['port'] = 7932
     if 'min_height' not in settings:
         settings['min_height'] = 0
     if 'max_height' not in settings:

--- a/contrib/qos/README.md
+++ b/contrib/qos/README.md
@@ -1,5 +1,5 @@
 ### QoS (Quality of service) ###
 
-This is a Linux bash script that will set up tc to limit the outgoing bandwidth for connections to the Bitcoin network. It limits outbound TCP traffic with a source or destination port of 8333, but not if the destination IP is within a LAN.
+This is a Linux bash script that will set up tc to limit the outgoing bandwidth for connections to the Bitcoin network. It limits outbound TCP traffic with a source or destination port of 7933, but not if the destination IP is within a LAN.
 
 This means one can have an always-on bitcoind instance running, and another local bitcoind/bitcoin-qt instance which connects to this node and receives blocks from it.

--- a/contrib/qos/tc.sh
+++ b/contrib/qos/tc.sh
@@ -44,16 +44,16 @@ fi
 #	ret=$?
 #done
 
-#limit outgoing traffic to and from port 8333. but not when dealing with a host on the local network
+#limit outgoing traffic to and from port 7933. but not when dealing with a host on the local network
 #	(defined by $LOCALNET_V4 and $LOCALNET_V6)
 #	--set-mark marks packages matching these criteria with the number "2" (v4)
 #	--set-mark marks packages matching these criteria with the number "4" (v6)
 #	these packets are filtered by the tc filter with "handle 2"
 #	this filter sends the packages into the 1:11 class, and this class is limited to ${LIMIT}
-iptables -t mangle -A OUTPUT -p tcp -m tcp --dport 8333 ! -d ${LOCALNET_V4} -j MARK --set-mark 0x2
-iptables -t mangle -A OUTPUT -p tcp -m tcp --sport 8333 ! -d ${LOCALNET_V4} -j MARK --set-mark 0x2
+iptables -t mangle -A OUTPUT -p tcp -m tcp --dport 7933 ! -d ${LOCALNET_V4} -j MARK --set-mark 0x2
+iptables -t mangle -A OUTPUT -p tcp -m tcp --sport 7933 ! -d ${LOCALNET_V4} -j MARK --set-mark 0x2
 
 if [ ! -z "${LOCALNET_V6}" ] ; then
-	ip6tables -t mangle -A OUTPUT -p tcp -m tcp --dport 8333 ! -d ${LOCALNET_V6} -j MARK --set-mark 0x4
-	ip6tables -t mangle -A OUTPUT -p tcp -m tcp --sport 8333 ! -d ${LOCALNET_V6} -j MARK --set-mark 0x4
+	ip6tables -t mangle -A OUTPUT -p tcp -m tcp --dport 7933 ! -d ${LOCALNET_V6} -j MARK --set-mark 0x4
+	ip6tables -t mangle -A OUTPUT -p tcp -m tcp --sport 7933 ! -d ${LOCALNET_V6} -j MARK --set-mark 0x4
 fi

--- a/contrib/rpm/bitcoin.spec
+++ b/contrib/rpm/bitcoin.spec
@@ -332,12 +332,12 @@ if [ `%{_sbindir}/sestatus |grep -c "disabled"` -eq 0 ]; then
 for selinuxvariant in %{selinux_variants}; do
 	%{_sbindir}/semodule -s ${selinuxvariant} -i %{_datadir}/selinux/${selinuxvariant}/bitcoin.pp &> /dev/null || :
 done
-%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 8332
-%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 8333
-%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 18332
-%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 18333
-%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 18443
-%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 18444
+%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 7932
+%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 7933
+%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 17932
+%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 17933
+%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 17443
+%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 17444
 %{_sbindir}/fixfiles -R bitcoin-server restore &> /dev/null || :
 %{_sbindir}/restorecon -R %{_localstatedir}/lib/bitcoin || :
 fi
@@ -353,12 +353,12 @@ fi
 # SELinux
 if [ $1 -eq 0 ]; then
 	if [ `%{_sbindir}/sestatus |grep -c "disabled"` -eq 0 ]; then
-	%{_sbindir}/semanage port -d -p tcp 8332
-	%{_sbindir}/semanage port -d -p tcp 8333
-	%{_sbindir}/semanage port -d -p tcp 18332
-	%{_sbindir}/semanage port -d -p tcp 18333
-	%{_sbindir}/semanage port -d -p tcp 18443
-	%{_sbindir}/semanage port -d -p tcp 18444
+	%{_sbindir}/semanage port -d -p tcp 7932
+	%{_sbindir}/semanage port -d -p tcp 7933
+	%{_sbindir}/semanage port -d -p tcp 17932
+	%{_sbindir}/semanage port -d -p tcp 17933
+	%{_sbindir}/semanage port -d -p tcp 17443
+	%{_sbindir}/semanage port -d -p tcp 17444
 	for selinuxvariant in %{selinux_variants}; do
 		%{_sbindir}/semodule -s ${selinuxvariant} -r bitcoin &> /dev/null || :
 	done
@@ -428,6 +428,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Fri Jul 20 2018 Jon Layton <jonlaytonmail@gmail.com> - 0.12.0-3
+- Adjust ports for Bitcoin Private
+
 * Fri Feb 26 2016 Alice Wonder <buildmaster@librelamp.com> - 0.12.0-2
 - Rename Qt package from bitcoin to bitcoin-core
 - Make building of the Qt package optional

--- a/contrib/seeds/generate-seeds.py
+++ b/contrib/seeds/generate-seeds.py
@@ -128,10 +128,10 @@ def main():
     g.write(' * IPv4 as well as onion addresses are wrapped inside an IPv6 address accordingly.\n')
     g.write(' */\n')
     with open(os.path.join(indir,'nodes_main.txt'),'r') as f:
-        process_nodes(g, f, 'pnSeed6_main', 8333)
+        process_nodes(g, f, 'pnSeed6_main', 7933)
     g.write('\n')
     with open(os.path.join(indir,'nodes_test.txt'),'r') as f:
-        process_nodes(g, f, 'pnSeed6_test', 18333)
+        process_nodes(g, f, 'pnSeed6_test', 17933)
     g.write('#endif // BITCOIN_CHAINPARAMSSEEDS_H\n')
 
 if __name__ == '__main__':

--- a/contrib/zmq/zmq_sub.py
+++ b/contrib/zmq/zmq_sub.py
@@ -8,10 +8,10 @@
 
     Bitcoin should be started with the command line arguments:
         bitcoind -testnet -daemon \
-                -zmqpubrawtx=tcp://127.0.0.1:28332 \
-                -zmqpubrawblock=tcp://127.0.0.1:28332 \
-                -zmqpubhashtx=tcp://127.0.0.1:28332 \
-                -zmqpubhashblock=tcp://127.0.0.1:28332
+                -zmqpubrawtx=tcp://127.0.0.1:27932 \
+                -zmqpubrawblock=tcp://127.0.0.1:27932 \
+                -zmqpubhashtx=tcp://127.0.0.1:27932 \
+                -zmqpubhashblock=tcp://127.0.0.1:27932
 
     We use the asyncio library here.  `self.handle()` installs itself as a
     future at the end of the function.  Since it never returns with the event
@@ -34,7 +34,7 @@ if not (sys.version_info.major >= 3 and sys.version_info.minor >= 5):
     print("This example only works with Python 3.5 and greater")
     sys.exit(1)
 
-port = 28332
+port = 27932
 
 class ZMQHandler():
     def __init__(self):

--- a/contrib/zmq/zmq_sub3.4.py
+++ b/contrib/zmq/zmq_sub3.4.py
@@ -8,10 +8,10 @@
 
     Bitcoin should be started with the command line arguments:
         bitcoind -testnet -daemon \
-                -zmqpubrawtx=tcp://127.0.0.1:28332 \
-                -zmqpubrawblock=tcp://127.0.0.1:28332 \
-                -zmqpubhashtx=tcp://127.0.0.1:28332 \
-                -zmqpubhashblock=tcp://127.0.0.1:28332
+                -zmqpubrawtx=tcp://127.0.0.1:27932 \
+                -zmqpubrawblock=tcp://127.0.0.1:27932 \
+                -zmqpubhashtx=tcp://127.0.0.1:27932 \
+                -zmqpubhashblock=tcp://127.0.0.1:27932
 
     We use the asyncio library here.  `self.handle()` installs itself as a
     future at the end of the function.  Since it never returns with the event
@@ -38,7 +38,7 @@ if not (sys.version_info.major >= 3 and sys.version_info.minor >= 4):
     print("This example only works with Python 3.4 and greater")
     sys.exit(1)
 
-port = 28332
+port = 27932
 
 class ZMQHandler():
     def __init__(self):

--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -3,8 +3,8 @@ Unauthenticated REST Interface
 
 The REST API can be enabled with the `-rest` option.
 
-The interface runs on the same port as the JSON-RPC interface, by default port 8332 for mainnet, port 18332 for testnet,
-and port 18443 for regtest.
+The interface runs on the same port as the JSON-RPC interface, by default port 7932 for mainnet, port 17932 for testnet,
+and port 17443 for regtest.
 
 Supported API
 -------------
@@ -58,7 +58,7 @@ https://github.com/bitcoin/bips/blob/master/bip-0064.mediawiki
 
 Example:
 ```
-$ curl localhost:18332/rest/getutxos/checkmempool/b2cdfd7b89def827ff8af7cd9bff7627ff72e5e8b0f71210f92ea7a4000c5d75-0.json 2>/dev/null | json_pp
+$ curl localhost:17932/rest/getutxos/checkmempool/b2cdfd7b89def827ff8af7cd9bff7627ff72e5e8b0f71210f92ea7a4000c5d75-0.json 2>/dev/null | json_pp
 {
    "chainHeight" : 325347,
    "chaintipHash" : "00000000fb01a7f3745a717f8caebee056c484e6e0bfe4a9591c235bb70506fb",
@@ -100,4 +100,4 @@ Only supports JSON as output format.
 
 Risks
 -------------
-Running a web browser on the same node with a REST enabled bitcoind can be a risk. Accessing prepared XSS websites could read out tx/block data of your node by placing links like `<script src="http://127.0.0.1:8332/rest/tx/1234567890.json">` which might break the nodes privacy.
+Running a web browser on the same node with a REST enabled bitcoind can be a risk. Accessing prepared XSS websites could read out tx/block data of your node by placing links like `<script src="http://127.0.0.1:7932/rest/tx/1234567890.json">` which might break the nodes privacy.

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -326,7 +326,7 @@ Threads
 
 - ThreadMapPort : Universal plug-and-play startup/shutdown
 
-- ThreadSocketHandler : Sends/Receives data from peers on port 8333.
+- ThreadSocketHandler : Sends/Receives data from peers on port 7933.
 
 - ThreadOpenAddedConnections : Opens network connections to added nodes.
 
@@ -336,7 +336,7 @@ Threads
 
 - DumpAddresses : Dumps IP addresses of nodes to peers.dat.
 
-- ThreadRPCServer : Remote procedure call handler, listens on port 8332 for connections and services them.
+- ThreadRPCServer : Remote procedure call handler, listens on port 7932 for connections and services them.
 
 - Shutdown : Does an orderly shutdown of everything.
 

--- a/doc/man/bitcoin-cli.1
+++ b/doc/man/bitcoin-cli.1
@@ -56,7 +56,7 @@ Send commands to node running on <ip> (default: 127.0.0.1)
 .HP
 \fB\-rpcport=\fR<port>
 .IP
-Connect to JSON\-RPC on <port> (default: 8332 or testnet: 18332)
+Connect to JSON\-RPC on <port> (default: 7932 or testnet: 17932)
 .HP
 \fB\-rpcwait\fR
 .IP

--- a/doc/man/bitcoin-qt.1
+++ b/doc/man/bitcoin-qt.1
@@ -213,7 +213,7 @@ Support filtering of blocks and transaction with bloom filters (default:
 .HP
 \fB\-port=\fR<port>
 .IP
-Listen for connections on <port> (default: 8333 or testnet: 18333)
+Listen for connections on <port> (default: 7933 or testnet: 17933)
 .HP
 \fB\-proxy=\fR<ip:port>
 .IP
@@ -521,8 +521,8 @@ option can be specified multiple times
 .HP
 \fB\-rpcport=\fR<port>
 .IP
-Listen for JSON\-RPC connections on <port> (default: 8332 or testnet:
-18332)
+Listen for JSON\-RPC connections on <port> (default: 7932 or testnet:
+17932)
 .HP
 \fB\-rpcallowip=\fR<ip>
 .IP

--- a/doc/man/bitcoind.1
+++ b/doc/man/bitcoind.1
@@ -218,7 +218,7 @@ Support filtering of blocks and transaction with bloom filters (default:
 .HP
 \fB\-port=\fR<port>
 .IP
-Listen for connections on <port> (default: 8333 or testnet: 18333)
+Listen for connections on <port> (default: 7933 or testnet: 17933)
 .HP
 \fB\-proxy=\fR<ip:port>
 .IP
@@ -526,8 +526,8 @@ option can be specified multiple times
 .HP
 \fB\-rpcport=\fR<port>
 .IP
-Listen for JSON\-RPC connections on <port> (default: 8332 or testnet:
-18332)
+Listen for JSON\-RPC connections on <port> (default: 7932 or testnet:
+17932)
 .HP
 \fB\-rpcallowip=\fR<ip>
 .IP

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -40,11 +40,11 @@ config file): *Needed for Tor version 0.2.7.0 and older versions of Tor only. Fo
 versions of Tor see [Section 3](#3-automatically-listen-on-tor).*
 
 	HiddenServiceDir /var/lib/tor/bitcoin-service/
-	HiddenServicePort 8333 127.0.0.1:8333
-	HiddenServicePort 18333 127.0.0.1:18333
+	HiddenServicePort 7933 127.0.0.1:7933
+	HiddenServicePort 17933 127.0.0.1:17933
 
 The directory can be different of course, but (both) port numbers should be equal to
-your bitcoind's P2P listen port (8333 by default).
+your bitcoind's P2P listen port (7933 by default).
 
 	-externalip=X   You can tell bitcoin about its publicly reachable address using
 	                this option, and this can be a .onion address. Given the above
@@ -79,7 +79,7 @@ as well, use `discover` instead:
 
 	./bitcoind ... -discover
 
-and open port 8333 on your firewall (or use -upnp).
+and open port 7933 on your firewall (or use -upnp).
 
 If you only want to use Tor to reach onion addresses, but not use it as a proxy
 for normal IPv4/IPv6 communication, use:

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -66,7 +66,7 @@ address. The same address can be used in more than one notification.
 
 For instance:
 
-    $ bitcoind -zmqpubhashtx=tcp://127.0.0.1:28332 \
+    $ bitcoind -zmqpubhashtx=tcp://127.0.0.1:27932 \
                -zmqpubrawtx=ipc:///tmp/bitcoind.tx.raw
 
 Each PUB notification has a topic and body, where the header

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -202,7 +202,7 @@ public:
 };
 
 /**
- * Testnet (v3)
+ * Testnet
  */
 class CTestNetParams : public CChainParams {
 public:
@@ -351,7 +351,7 @@ public:
         pchMessageStart[2] = 0x3f;
         pchMessageStart[3] = 0x5f;
 
-        nDefaultPort = 17944;
+        nDefaultPort = 17444;
 
         nPruneAfterHeight = 1000;
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -32,11 +32,11 @@ const CBaseChainParams& BaseParams()
 std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN)
-        return MakeUnique<CBaseChainParams>("", 8332);
+        return MakeUnique<CBaseChainParams>("", 7932);
     else if (chain == CBaseChainParams::TESTNET)
-        return MakeUnique<CBaseChainParams>("testnet3", 18332);
+        return MakeUnique<CBaseChainParams>("testnet", 17932);
     else if (chain == CBaseChainParams::REGTEST)
-        return MakeUnique<CBaseChainParams>("regtest", 18443);
+        return MakeUnique<CBaseChainParams>("regtest", 17443);
     else
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -207,8 +207,8 @@ static UniValue addnode(const JSONRPCRequest& request)
             "1. \"node\"     (string, required) The node (see getpeerinfo for nodes)\n"
             "2. \"command\"  (string, required) 'add' to add a node to the list, 'remove' to remove a node from the list, 'onetry' to try a connection to the node once\n"
             "\nExamples:\n"
-            + HelpExampleCli("addnode", "\"192.168.0.6:8333\" \"onetry\"")
-            + HelpExampleRpc("addnode", "\"192.168.0.6:8333\", \"onetry\"")
+            + HelpExampleCli("addnode", "\"192.168.0.6:7933\" \"onetry\"")
+            + HelpExampleRpc("addnode", "\"192.168.0.6:7933\", \"onetry\"")
         );
 
     if(!g_connman)
@@ -249,9 +249,9 @@ static UniValue disconnectnode(const JSONRPCRequest& request)
             "1. \"address\"     (string, optional) The IP address/port of the node\n"
             "2. \"nodeid\"      (number, optional) The node ID (see getpeerinfo for node IDs)\n"
             "\nExamples:\n"
-            + HelpExampleCli("disconnectnode", "\"192.168.0.6:8333\"")
+            + HelpExampleCli("disconnectnode", "\"192.168.0.6:7933\"")
             + HelpExampleCli("disconnectnode", "\"\" 1")
-            + HelpExampleRpc("disconnectnode", "\"192.168.0.6:8333\"")
+            + HelpExampleRpc("disconnectnode", "\"192.168.0.6:7933\"")
             + HelpExampleRpc("disconnectnode", "\"\", 1")
         );
 
@@ -296,7 +296,7 @@ static UniValue getaddednodeinfo(const JSONRPCRequest& request)
             "    \"connected\" : true|false,          (boolean) If connected\n"
             "    \"addresses\" : [                    (list of objects) Only when connected = true\n"
             "       {\n"
-            "         \"address\" : \"192.168.0.201:8333\",  (string) The bitcoin server IP and port we're connected to\n"
+            "         \"address\" : \"192.168.0.201:7933\",  (string) The bitcoin server IP and port we're connected to\n"
             "         \"connected\" : \"outbound\"           (string) connection, inbound or outbound\n"
             "       }\n"
             "     ]\n"

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -522,7 +522,7 @@ std::string HelpExampleCli(const std::string& methodname, const std::string& arg
 std::string HelpExampleRpc(const std::string& methodname, const std::string& args)
 {
     return "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", "
-        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:8332/\n";
+        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:7932/\n";
 }
 
 void RPCSetTimerInterfaceIfUnset(RPCTimerInterface *iface)

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -103,15 +103,15 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
     BOOST_CHECK_EQUAL(addr_null.ToString(), "[::]:0");
 
     // Test: Does Addrman::Add work as expected.
-    CService addr1 = ResolveService("250.1.1.1", 8333);
+    CService addr1 = ResolveService("250.1.1.1", 7933);
     BOOST_CHECK(addrman.Add(CAddress(addr1, NODE_NONE), source));
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
     CAddrInfo addr_ret1 = addrman.Select();
-    BOOST_CHECK_EQUAL(addr_ret1.ToString(), "250.1.1.1:8333");
+    BOOST_CHECK_EQUAL(addr_ret1.ToString(), "250.1.1.1:7933");
 
     // Test: Does IP address deduplication work correctly.
     //  Expected dup IP should not be added.
-    CService addr1_dup = ResolveService("250.1.1.1", 8333);
+    CService addr1_dup = ResolveService("250.1.1.1", 7933);
     BOOST_CHECK(!addrman.Add(CAddress(addr1_dup, NODE_NONE), source));
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
 
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
     // hash collisions may occur. But we can always be sure of at least one
     // success.
 
-    CService addr2 = ResolveService("250.1.1.2", 8333);
+    CService addr2 = ResolveService("250.1.1.2", 7933);
     BOOST_CHECK(addrman.Add(CAddress(addr2, NODE_NONE), source));
     BOOST_CHECK(addrman.size() >= 1);
 
@@ -134,8 +134,8 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
 
     // Test: AddrMan::Add multiple addresses works as expected
     std::vector<CAddress> vAddr;
-    vAddr.push_back(CAddress(ResolveService("250.1.1.3", 8333), NODE_NONE));
-    vAddr.push_back(CAddress(ResolveService("250.1.1.4", 8333), NODE_NONE));
+    vAddr.push_back(CAddress(ResolveService("250.1.1.3", 7933), NODE_NONE));
+    vAddr.push_back(CAddress(ResolveService("250.1.1.4", 7933), NODE_NONE));
     BOOST_CHECK(addrman.Add(vAddr, source));
     BOOST_CHECK(addrman.size() >= 1);
 }
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(addrman_ports)
     BOOST_CHECK_EQUAL(addrman.size(), 0U);
 
     // Test 7; Addr with same IP but diff port does not replace existing addr.
-    CService addr1 = ResolveService("250.1.1.1", 8333);
+    CService addr1 = ResolveService("250.1.1.1", 7933);
     addrman.Add(CAddress(addr1, NODE_NONE), source);
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
 
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(addrman_ports)
     addrman.Add(CAddress(addr1_port, NODE_NONE), source);
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
     CAddrInfo addr_ret2 = addrman.Select();
-    BOOST_CHECK_EQUAL(addr_ret2.ToString(), "250.1.1.1:8333");
+    BOOST_CHECK_EQUAL(addr_ret2.ToString(), "250.1.1.1:7933");
 
     // Test: Add same IP but diff port to tried table, it doesn't get added.
     //  Perhaps this is not ideal behavior but it is the current behavior.
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(addrman_ports)
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
     bool newOnly = true;
     CAddrInfo addr_ret3 = addrman.Select(newOnly);
-    BOOST_CHECK_EQUAL(addr_ret3.ToString(), "250.1.1.1:8333");
+    BOOST_CHECK_EQUAL(addr_ret3.ToString(), "250.1.1.1:7933");
 }
 
 
@@ -176,13 +176,13 @@ BOOST_AUTO_TEST_CASE(addrman_select)
     CNetAddr source = ResolveIP("252.2.2.2");
 
     // Test: Select from new with 1 addr in new.
-    CService addr1 = ResolveService("250.1.1.1", 8333);
+    CService addr1 = ResolveService("250.1.1.1", 7933);
     addrman.Add(CAddress(addr1, NODE_NONE), source);
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
 
     bool newOnly = true;
     CAddrInfo addr_ret1 = addrman.Select(newOnly);
-    BOOST_CHECK_EQUAL(addr_ret1.ToString(), "250.1.1.1:8333");
+    BOOST_CHECK_EQUAL(addr_ret1.ToString(), "250.1.1.1:7933");
 
     // Test: move addr to tried, select from new expected nothing returned.
     addrman.Good(CAddress(addr1, NODE_NONE));
@@ -191,30 +191,30 @@ BOOST_AUTO_TEST_CASE(addrman_select)
     BOOST_CHECK_EQUAL(addr_ret2.ToString(), "[::]:0");
 
     CAddrInfo addr_ret3 = addrman.Select();
-    BOOST_CHECK_EQUAL(addr_ret3.ToString(), "250.1.1.1:8333");
+    BOOST_CHECK_EQUAL(addr_ret3.ToString(), "250.1.1.1:7933");
 
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
 
 
     // Add three addresses to new table.
-    CService addr2 = ResolveService("250.3.1.1", 8333);
+    CService addr2 = ResolveService("250.3.1.1", 7933);
     CService addr3 = ResolveService("250.3.2.2", 9999);
     CService addr4 = ResolveService("250.3.3.3", 9999);
 
-    addrman.Add(CAddress(addr2, NODE_NONE), ResolveService("250.3.1.1", 8333));
-    addrman.Add(CAddress(addr3, NODE_NONE), ResolveService("250.3.1.1", 8333));
-    addrman.Add(CAddress(addr4, NODE_NONE), ResolveService("250.4.1.1", 8333));
+    addrman.Add(CAddress(addr2, NODE_NONE), ResolveService("250.3.1.1", 7933));
+    addrman.Add(CAddress(addr3, NODE_NONE), ResolveService("250.3.1.1", 7933));
+    addrman.Add(CAddress(addr4, NODE_NONE), ResolveService("250.4.1.1", 7933));
 
     // Add three addresses to tried table.
-    CService addr5 = ResolveService("250.4.4.4", 8333);
+    CService addr5 = ResolveService("250.4.4.4", 7933);
     CService addr6 = ResolveService("250.4.5.5", 7777);
-    CService addr7 = ResolveService("250.4.6.6", 8333);
+    CService addr7 = ResolveService("250.4.6.6", 7933);
 
-    addrman.Add(CAddress(addr5, NODE_NONE), ResolveService("250.3.1.1", 8333));
+    addrman.Add(CAddress(addr5, NODE_NONE), ResolveService("250.3.1.1", 7933));
     addrman.Good(CAddress(addr5, NODE_NONE));
-    addrman.Add(CAddress(addr6, NODE_NONE), ResolveService("250.3.1.1", 8333));
+    addrman.Add(CAddress(addr6, NODE_NONE), ResolveService("250.3.1.1", 7933));
     addrman.Good(CAddress(addr6, NODE_NONE));
-    addrman.Add(CAddress(addr7, NODE_NONE), ResolveService("250.1.1.3", 8333));
+    addrman.Add(CAddress(addr7, NODE_NONE), ResolveService("250.1.1.3", 7933));
     addrman.Good(CAddress(addr7, NODE_NONE));
 
     // Test: 6 addrs + 1 addr from last test = 7.
@@ -287,9 +287,9 @@ BOOST_AUTO_TEST_CASE(addrman_find)
 
     BOOST_CHECK_EQUAL(addrman.size(), 0U);
 
-    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
+    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 7933), NODE_NONE);
     CAddress addr2 = CAddress(ResolveService("250.1.2.1", 9999), NODE_NONE);
-    CAddress addr3 = CAddress(ResolveService("251.255.2.1", 8333), NODE_NONE);
+    CAddress addr3 = CAddress(ResolveService("251.255.2.1", 7933), NODE_NONE);
 
     CNetAddr source1 = ResolveIP("250.1.2.1");
     CNetAddr source2 = ResolveIP("250.1.2.2");
@@ -301,7 +301,7 @@ BOOST_AUTO_TEST_CASE(addrman_find)
     // Test: ensure Find returns an IP matching what we searched on.
     CAddrInfo* info1 = addrman.Find(addr1);
     BOOST_REQUIRE(info1);
-    BOOST_CHECK_EQUAL(info1->ToString(), "250.1.2.1:8333");
+    BOOST_CHECK_EQUAL(info1->ToString(), "250.1.2.1:7933");
 
     // Test 18; Find does not discriminate by port number.
     CAddrInfo* info2 = addrman.Find(addr2);
@@ -311,7 +311,7 @@ BOOST_AUTO_TEST_CASE(addrman_find)
     // Test: Find returns another IP matching what we searched on.
     CAddrInfo* info3 = addrman.Find(addr3);
     BOOST_REQUIRE(info3);
-    BOOST_CHECK_EQUAL(info3->ToString(), "251.255.2.1:8333");
+    BOOST_CHECK_EQUAL(info3->ToString(), "251.255.2.1:7933");
 }
 
 BOOST_AUTO_TEST_CASE(addrman_create)
@@ -320,17 +320,17 @@ BOOST_AUTO_TEST_CASE(addrman_create)
 
     BOOST_CHECK_EQUAL(addrman.size(), 0U);
 
-    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
+    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 7933), NODE_NONE);
     CNetAddr source1 = ResolveIP("250.1.2.1");
 
     int nId;
     CAddrInfo* pinfo = addrman.Create(addr1, source1, &nId);
 
     // Test: The result should be the same as the input addr.
-    BOOST_CHECK_EQUAL(pinfo->ToString(), "250.1.2.1:8333");
+    BOOST_CHECK_EQUAL(pinfo->ToString(), "250.1.2.1:7933");
 
     CAddrInfo* info2 = addrman.Find(addr1);
-    BOOST_CHECK_EQUAL(info2->ToString(), "250.1.2.1:8333");
+    BOOST_CHECK_EQUAL(info2->ToString(), "250.1.2.1:7933");
 }
 
 
@@ -340,7 +340,7 @@ BOOST_AUTO_TEST_CASE(addrman_delete)
 
     BOOST_CHECK_EQUAL(addrman.size(), 0U);
 
-    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
+    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 7933), NODE_NONE);
     CNetAddr source1 = ResolveIP("250.1.2.1");
 
     int nId;
@@ -364,15 +364,15 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
     std::vector<CAddress> vAddr1 = addrman.GetAddr();
     BOOST_CHECK_EQUAL(vAddr1.size(), 0U);
 
-    CAddress addr1 = CAddress(ResolveService("250.250.2.1", 8333), NODE_NONE);
+    CAddress addr1 = CAddress(ResolveService("250.250.2.1", 7933), NODE_NONE);
     addr1.nTime = GetAdjustedTime(); // Set time so isTerrible = false
     CAddress addr2 = CAddress(ResolveService("250.251.2.2", 9999), NODE_NONE);
     addr2.nTime = GetAdjustedTime();
-    CAddress addr3 = CAddress(ResolveService("251.252.2.3", 8333), NODE_NONE);
+    CAddress addr3 = CAddress(ResolveService("251.252.2.3", 7933), NODE_NONE);
     addr3.nTime = GetAdjustedTime();
-    CAddress addr4 = CAddress(ResolveService("252.253.3.4", 8333), NODE_NONE);
+    CAddress addr4 = CAddress(ResolveService("252.253.3.4", 7933), NODE_NONE);
     addr4.nTime = GetAdjustedTime();
-    CAddress addr5 = CAddress(ResolveService("252.254.4.5", 8333), NODE_NONE);
+    CAddress addr5 = CAddress(ResolveService("252.254.4.5", 7933), NODE_NONE);
     addr5.nTime = GetAdjustedTime();
     CNetAddr source1 = ResolveIP("250.1.2.1");
     CNetAddr source2 = ResolveIP("250.2.3.3");
@@ -419,7 +419,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
 {
     CAddrManTest addrman;
 
-    CAddress addr1 = CAddress(ResolveService("250.1.1.1", 8333), NODE_NONE);
+    CAddress addr1 = CAddress(ResolveService("250.1.1.1", 7933), NODE_NONE);
     CAddress addr2 = CAddress(ResolveService("250.1.1.1", 9999), NODE_NONE);
 
     CNetAddr source1 = ResolveIP("250.1.1.1");
@@ -473,7 +473,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
 {
     CAddrManTest addrman;
 
-    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
+    CAddress addr1 = CAddress(ResolveService("250.1.2.1", 7933), NODE_NONE);
     CAddress addr2 = CAddress(ResolveService("250.1.2.1", 9999), NODE_NONE);
 
     CNetAddr source1 = ResolveIP("250.1.2.1");

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -93,13 +93,13 @@ BOOST_AUTO_TEST_CASE(caddrdb_read)
     addrmanUncorrupted.MakeDeterministic();
 
     CService addr1, addr2, addr3;
-    Lookup("250.7.1.1", addr1, 8333, false);
+    Lookup("250.7.1.1", addr1, 7933, false);
     Lookup("250.7.2.2", addr2, 9999, false);
     Lookup("250.7.3.3", addr3, 9999, false);
 
     // Add three addresses to new table.
     CService source;
-    Lookup("252.5.1.1", source, 8333, false);
+    Lookup("252.5.1.1", source, 7933, false);
     addrmanUncorrupted.Add(CAddress(addr1, NODE_NONE), source);
     addrmanUncorrupted.Add(CAddress(addr2, NODE_NONE), source);
     addrmanUncorrupted.Add(CAddress(addr3, NODE_NONE), source);

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -87,15 +87,15 @@ BOOST_AUTO_TEST_CASE(netbase_splithost)
     BOOST_CHECK(TestSplitHost("www.bitcoin.org:80", "www.bitcoin.org", 80));
     BOOST_CHECK(TestSplitHost("[www.bitcoin.org]:80", "www.bitcoin.org", 80));
     BOOST_CHECK(TestSplitHost("127.0.0.1", "127.0.0.1", -1));
-    BOOST_CHECK(TestSplitHost("127.0.0.1:8333", "127.0.0.1", 8333));
+    BOOST_CHECK(TestSplitHost("127.0.0.1:7933", "127.0.0.1", 7933));
     BOOST_CHECK(TestSplitHost("[127.0.0.1]", "127.0.0.1", -1));
-    BOOST_CHECK(TestSplitHost("[127.0.0.1]:8333", "127.0.0.1", 8333));
+    BOOST_CHECK(TestSplitHost("[127.0.0.1]:7933", "127.0.0.1", 7933));
     BOOST_CHECK(TestSplitHost("::ffff:127.0.0.1", "::ffff:127.0.0.1", -1));
-    BOOST_CHECK(TestSplitHost("[::ffff:127.0.0.1]:8333", "::ffff:127.0.0.1", 8333));
-    BOOST_CHECK(TestSplitHost("[::]:8333", "::", 8333));
-    BOOST_CHECK(TestSplitHost("::8333", "::8333", -1));
-    BOOST_CHECK(TestSplitHost(":8333", "", 8333));
-    BOOST_CHECK(TestSplitHost("[]:8333", "", 8333));
+    BOOST_CHECK(TestSplitHost("[::ffff:127.0.0.1]:7933", "::ffff:127.0.0.1", 7933));
+    BOOST_CHECK(TestSplitHost("[::]:7933", "::", 7933));
+    BOOST_CHECK(TestSplitHost("::7933", "::7933", -1));
+    BOOST_CHECK(TestSplitHost(":7933", "", 7933));
+    BOOST_CHECK(TestSplitHost("[]:7933", "", 7933));
     BOOST_CHECK(TestSplitHost("", "", -1));
 }
 
@@ -108,10 +108,10 @@ bool static TestParse(std::string src, std::string canon)
 BOOST_AUTO_TEST_CASE(netbase_lookupnumeric)
 {
     BOOST_CHECK(TestParse("127.0.0.1", "127.0.0.1:65535"));
-    BOOST_CHECK(TestParse("127.0.0.1:8333", "127.0.0.1:8333"));
+    BOOST_CHECK(TestParse("127.0.0.1:7933", "127.0.0.1:7933"));
     BOOST_CHECK(TestParse("::ffff:127.0.0.1", "127.0.0.1:65535"));
     BOOST_CHECK(TestParse("::", "[::]:65535"));
-    BOOST_CHECK(TestParse("[::]:8333", "[::]:8333"));
+    BOOST_CHECK(TestParse("[::]:7933", "[::]:7933"));
     BOOST_CHECK(TestParse("[127.0.0.1]", "127.0.0.1:65535"));
     BOOST_CHECK(TestParse(":::", "[::]:0"));
 

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -120,24 +120,24 @@ class ProxyTest(BitcoinTestFramework):
 
         if test_onion:
             # Test: outgoing onion connection through node
-            node.addnode("bitcoinostk4e4re.onion:8333", "onetry")
+            node.addnode("bitcoinostk4e4re.onion:7933", "onetry")
             cmd = proxies[2].queue.get()
             assert(isinstance(cmd, Socks5Command))
             assert_equal(cmd.atyp, AddressType.DOMAINNAME)
             assert_equal(cmd.addr, b"bitcoinostk4e4re.onion")
-            assert_equal(cmd.port, 8333)
+            assert_equal(cmd.port, 7933)
             if not auth:
                 assert_equal(cmd.username, None)
                 assert_equal(cmd.password, None)
             rv.append(cmd)
 
         # Test: outgoing DNS name connection through node
-        node.addnode("node.noumenon:8333", "onetry")
+        node.addnode("node.noumenon:7933", "onetry")
         cmd = proxies[3].queue.get()
         assert(isinstance(cmd, Socks5Command))
         assert_equal(cmd.atyp, AddressType.DOMAINNAME)
         assert_equal(cmd.addr, b"node.noumenon")
-        assert_equal(cmd.port, 8333)
+        assert_equal(cmd.port, 7933)
         if not auth:
             assert_equal(cmd.username, None)
             assert_equal(cmd.password, None)

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -56,7 +56,7 @@ class ZMQTest (BitcoinTestFramework):
         # that this test fails if the publishing order changes.
         # Note that the publishing order is not defined in the documentation and
         # is subject to change.
-        address = "tcp://127.0.0.1:28332"
+        address = "tcp://127.0.0.1:27932"
         self.zmq_context = zmq.Context()
         socket = self.zmq_context.socket(zmq.SUB)
         socket.set(zmq.RCVTIMEO, 60000)


### PR DESCRIPTION
**P2P & RPC:**
Mainnet: 7933 & 7932
Testnet: 17933 & 17932
Regtest: 17444 & 17443

**ZMQ:**
27932