### PR TITLE
Enable rebase-in-progress to build on macOS High Sierra

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,24 @@ This should build on linux and sync the full BTCP mainnet chain. Wallet code and
 
 Build Instructions
 -------
-Only linux builds have been reasonably tested. `scripts/build/sh` should build all the dependencies and bootstrap a linux build. If you want to manually configure, you must pass --disable-wallet currently.
+Only linux builds have been reasonably tested. `scripts/build/sh` should build all the dependencies and bootstrap a linux build.
+
+For macOS High Sierra users, compilation can be achieved by first installing libomp (necessary as Apple's version of Clang does not have support for OpenMP included); you can do that via the following Terminal commands:
+
+Install XCode:
+```
+xcode-select --install
+```
+Install Homebrew:
+```
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+```
+Install libomp:
+```
+brew install libomp
+```
+Then run the `scripts/build-mac.sh` to compile.
+
 
 https://btcprivate.org
 

--- a/configure.ac
+++ b/configure.ac
@@ -199,6 +199,17 @@ if test "x$use_asm" = xyes; then
   AC_DEFINE(USE_ASM, 1, [Define this symbol to build in assembly routines])
 fi
 
+dnl Temporary flag to get compilation on Mac working without interrupting Linux values
+AC_ARG_ENABLE([mac-build-script],
+  [AS_HELP_STRING([--mac-build-script],
+  [Enable mac-specific compilation values (default is no)])],
+  [mac_build_script=$enableval],
+  [mac_build_script=no])
+AM_CONDITIONAL([MAC_BUILD_SCRIPT],[test x$mac_build_script = xyes])
+if test "x$mac_build_script" = xyes; then
+  AC_DEFINE(MAC_BUILD_SCRIPT, 1, [Define this symbol to use mac-specific build values])
+fi
+
 AC_ARG_WITH([system-univalue],
   [AS_HELP_STRING([--with-system-univalue],
   [Build with system UniValue (default is no)])],

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -108,5 +108,5 @@ CPPFLAGS+="-Xpreprocessor -fopenmp -lomp -L/usr/local/opt/libomp/lib -I/usr/loca
 
 HOST="$HOST" BUILD="$BUILD" "$MAKE" "$@" -C ./depends/ V=1
 ./autogen.sh
-./configure --prefix="${PREFIX}" --host="$HOST" --build="$BUILD" "$HARDENING_ARG" "$LCOV_ARG" "$TEST_ARG" "$MINING_ARG" $CONFIGURE_FLAGS CXXFLAGS='-g' CPPFLAGS="${CPPFLAGS}"
+./configure --prefix="${PREFIX}" --host="$HOST" --build="$BUILD" "$HARDENING_ARG" "$LCOV_ARG" "$TEST_ARG" "$MINING_ARG" $CONFIGURE_FLAGS CXXFLAGS='-g' CPPFLAGS="${CPPFLAGS}" --enable-mac-build-script=yes
 "$MAKE" "$@" V=1

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+function cmd_pref() {
+    if type -p "$2" > /dev/null; then
+        eval "$1=$2"
+    else
+        eval "$1=$3"
+    fi
+}
+
+# If a g-prefixed version of the command exists, use it preferentially.
+function gprefix() {
+    cmd_pref "$1" "g$2" "$2"
+}
+
+gprefix READLINK readlink
+cd "$(dirname "$("$READLINK" -f "$0")")/.."
+
+# Allow user overrides to $MAKE. Typical usage for users who need it:
+#   MAKE=gmake ./zcutil/build.sh -j$(nproc)
+if [[ -z "${MAKE-}" ]]; then
+    MAKE=make
+fi
+
+# Allow overrides to $BUILD and $HOST for porters. Most users will not need it.
+#   BUILD=i686-pc-linux-gnu ./zcutil/build.sh
+if [[ -z "${BUILD-}" ]]; then
+    BUILD="$(./depends/config.guess)"
+fi
+if [[ -z "${HOST-}" ]]; then
+    HOST="$BUILD"
+fi
+
+# Allow override to $CC and $CXX for porters. Most users will not need it.
+if [[ -z "${CC-}" ]]; then
+    CC=gcc
+fi
+if [[ -z "${CXX-}" ]]; then
+    CXX=g++
+fi
+
+# Allow users to set arbitary compile flags. Most users will not need this.
+if [[ -z "${CONFIGURE_FLAGS-}" ]]; then
+    CONFIGURE_FLAGS=""
+fi
+
+if [ "x$*" = 'x--help' ]
+then
+    cat <<EOF
+Usage:
+
+$0 --help
+  Show this help message and exit.
+
+$0 [ --enable-lcov || --disable-tests ] [ --disable-mining ] [ MAKEARGS... ]
+  Build Zcash and most of its transitive dependencies from
+  source. MAKEARGS are applied to both dependencies and Zcash itself.
+
+  If --enable-lcov is passed, Zcash is configured to add coverage
+  instrumentation, thus enabling "make cov" to work.
+  If --disable-tests is passed instead, the Zcash tests are not built.
+
+  If --disable-mining is passed, Zcash is configured to not build any mining
+  code. It must be passed after the test arguments, if present.
+EOF
+    exit 0
+fi
+
+set -x
+
+# If --enable-lcov is the first argument, enable lcov coverage support:
+LCOV_ARG=''
+HARDENING_ARG='--enable-hardening'
+TEST_ARG=''
+if [ "x${1:-}" = 'x--enable-lcov' ]
+then
+    LCOV_ARG='--enable-lcov'
+    HARDENING_ARG='--disable-hardening'
+    shift
+elif [ "x${1:-}" = 'x--disable-tests' ]
+then
+    TEST_ARG='--enable-tests=no'
+    shift
+fi
+
+# If --disable-mining is the next argument, disable mining code:
+MINING_ARG=''
+if [ "x${1:-}" = 'x--disable-mining' ]
+then
+    MINING_ARG='--enable-mining=no'
+    shift
+fi
+
+PREFIX="$(pwd)/depends/$BUILD/"
+
+#$CC="$(shell brew --prefix llvm)/bin/clang"
+#$CXX="$(shell brew --prefix llvm)/bin/clang++"
+
+eval "$MAKE" --version
+eval "$CC" --version
+eval "$CXX" --version
+as --version
+ld -v
+
+CPPFLAGS+="-Xpreprocessor -fopenmp -lomp -L/usr/local/opt/libomp/lib -I/usr/local/opt/libomp/include"
+
+HOST="$HOST" BUILD="$BUILD" "$MAKE" "$@" -C ./depends/ V=1
+./autogen.sh
+./configure --prefix="${PREFIX}" --host="$HOST" --build="$BUILD" "$HARDENING_ARG" "$LCOV_ARG" "$TEST_ARG" "$MINING_ARG" $CONFIGURE_FLAGS CXXFLAGS='-g' CPPFLAGS="${CPPFLAGS}"
+"$MAKE" "$@" V=1

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -357,8 +357,10 @@ libbitcoin_consensus_a_SOURCES = \
   consensus/merkle.h \
   consensus/params.h \
   consensus/validation.h \
+  fs.cpp \
   hash.cpp \
   hash.h \
+  logging.cpp \
   prevector.h \
   primitives/block.cpp \
   primitives/block.h \
@@ -383,6 +385,7 @@ libbitcoin_consensus_a_SOURCES = \
   uint252.h \
   utilstrencodings.cpp \
   utilstrencodings.h \
+  utiltime.cpp \
   version.h
 
 # common: shared between bitcoind, and bitcoin-qt and non-server tools
@@ -545,7 +548,7 @@ libzcash_a_SOURCES = \
   zcash/circuit/prfs.tcc \
   zcash/circuit/utils.tcc
 
-libzcash_a_CPPFLAGS = -DMULTICORE -fopenmp -fPIC -DBINARY_OUTPUT -DCURVE_ALT_BN128 -DBOOST_SPIRIT_THREADSAFE -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS $(HARDENED_CPPFLAGS) $(HARDENED_CXXFLAGS) $(HARDENED_LDFLAGS) -pipe $(SAN_LDFLAGS) -O1 -g -Wstack-protector $(SAN_CXXFLAGS) -fstack-protector-all -fPIE -fvisibility=hidden -DSTATIC $(BITCOIN_INCLUDES)
+libzcash_a_CPPFLAGS = -DMULTICORE -Xpreprocessor -fopenmp -lomp -fPIC -DBINARY_OUTPUT -DCURVE_ALT_BN128 -DBOOST_SPIRIT_THREADSAFE -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS $(HARDENED_CPPFLAGS) $(HARDENED_CXXFLAGS) $(HARDENED_LDFLAGS) -pipe $(SAN_LDFLAGS) -O1 -g -Wstack-protector $(SAN_CXXFLAGS) -fstack-protector-all -fPIE -fvisibility=hidden -DSTATIC $(BITCOIN_INCLUDES)
 
 libzcash_a_CXXFLAGS = $(SAN_CXXFLAGS) $(HARDENED_CXXFLAGS) -fwrapv -fno-strict-aliasing
 
@@ -563,9 +566,9 @@ if GLIBC_BACK_COMPAT
 endif
 
 libbitcoinconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS)
-libbitcoinconsensus_la_LIBADD = $(LIBSECP256K1)
+libbitcoinconsensus_la_LIBADD = $(LIBSECP256K1) $(LIBZCASH)
 libbitcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL
-libbitcoinconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+libbitcoinconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)  -lboost_system-mt -lboost_filesystem-mt -lboost_thread-mt -lsodium
 
 endif
 #

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -553,7 +553,7 @@ libzcash_a_CPPFLAGS = -DMULTICORE
 if MAC_BUILD_SCRIPT
 libzcash_a_CPPFLAGS += -Xpreprocessor -fopenmp -lomp
 else
-libzcash_a_CPPFLAGS += fopenmp
+libzcash_a_CPPFLAGS += -fopenmp
 endif
 
 libzcash_a_CPPFLAGS += -fPIC -DBINARY_OUTPUT -DCURVE_ALT_BN128 -DBOOST_SPIRIT_THREADSAFE -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS $(HARDENED_CPPFLAGS) $(HARDENED_CXXFLAGS) $(HARDENED_LDFLAGS) -pipe $(SAN_LDFLAGS) -O1 -g -Wstack-protector $(SAN_CXXFLAGS) -fstack-protector-all -fPIE -fvisibility=hidden -DSTATIC $(BITCOIN_INCLUDES)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -548,7 +548,15 @@ libzcash_a_SOURCES = \
   zcash/circuit/prfs.tcc \
   zcash/circuit/utils.tcc
 
-libzcash_a_CPPFLAGS = -DMULTICORE -Xpreprocessor -fopenmp -lomp -fPIC -DBINARY_OUTPUT -DCURVE_ALT_BN128 -DBOOST_SPIRIT_THREADSAFE -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS $(HARDENED_CPPFLAGS) $(HARDENED_CXXFLAGS) $(HARDENED_LDFLAGS) -pipe $(SAN_LDFLAGS) -O1 -g -Wstack-protector $(SAN_CXXFLAGS) -fstack-protector-all -fPIE -fvisibility=hidden -DSTATIC $(BITCOIN_INCLUDES)
+libzcash_a_CPPFLAGS = -DMULTICORE 
+
+if MAC_BUILD_SCRIPT
+libzcash_a_CPPFLAGS += -Xpreprocessor -fopenmp -lomp
+else
+libzcash_a_CPPFLAGS += fopenmp
+endif
+
+libzcash_a_CPPFLAGS += -fPIC -DBINARY_OUTPUT -DCURVE_ALT_BN128 -DBOOST_SPIRIT_THREADSAFE -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS $(HARDENED_CPPFLAGS) $(HARDENED_CXXFLAGS) $(HARDENED_LDFLAGS) -pipe $(SAN_LDFLAGS) -O1 -g -Wstack-protector $(SAN_CXXFLAGS) -fstack-protector-all -fPIE -fvisibility=hidden -DSTATIC $(BITCOIN_INCLUDES)
 
 libzcash_a_CXXFLAGS = $(SAN_CXXFLAGS) $(HARDENED_CXXFLAGS) -fwrapv -fno-strict-aliasing
 
@@ -566,9 +574,18 @@ if GLIBC_BACK_COMPAT
 endif
 
 libbitcoinconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS)
-libbitcoinconsensus_la_LIBADD = $(LIBSECP256K1) $(LIBZCASH)
+libbitcoinconsensus_la_LIBADD = $(LIBSECP256K1) 
+
+if MAC_BUILD_SCRIPT
+libbitcoinconsensus_la_LIBADD += $(LIBZCASH)
+endif
+
 libbitcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL
-libbitcoinconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)  -lboost_system-mt -lboost_filesystem-mt -lboost_thread-mt -lsodium
+libbitcoinconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+
+if MAC_BUILD_SCRIPT
+libbitcoinconsensus_la_CXXFLAGS += -lboost_system-mt -lboost_filesystem-mt -lboost_thread-mt -lsodium
+endif
 
 endif
 #

--- a/src/snark/Makefile
+++ b/src/snark/Makefile
@@ -147,7 +147,7 @@ else
 endif
 
 ifeq ($(MULTICORE),1)
-	CXXFLAGS += -DMULTICORE -fopenmp
+	CXXFLAGS += -DMULTICORE -Xpreprocessor -fopenmp -lomp -L/usr/local/opt/libomp/lib -I/usr/local/opt/libomp/include
 endif
 
 ifeq ($(CPPDEBUG),1)

--- a/src/zcash/IncrementalMerkleTree.hpp
+++ b/src/zcash/IncrementalMerkleTree.hpp
@@ -1,6 +1,7 @@
 #ifndef ZC_INCREMENTALMERKLETREE_H_
 #define ZC_INCREMENTALMERKLETREE_H_
 
+#include <array>
 #include <deque>
 #include <boost/optional.hpp>
 #include <boost/static_assert.hpp>

--- a/src/zcash/NoteEncryption.hpp
+++ b/src/zcash/NoteEncryption.hpp
@@ -6,7 +6,7 @@ https://github.com/zcash/zips/blob/master/protocol/protocol.pdf
 #ifndef ZC_NOTE_ENCRYPTION_H_
 #define ZC_NOTE_ENCRYPTION_H_
 
-#include <boost/array.hpp>
+#include <array>
 #include "uint256.h"
 #include "uint252.h"
 


### PR DESCRIPTION
Includes minimum build config changes to compile and run successfully on macOS High Sierra, using libomp to support OpenMP while still using Apple's Clang and toolchain. No doubt this could be set up more elegantly, but this will allow mac developers to compile and move forward with other rebase issues, and it should be pretty straightforward to refactor by someone more familiar with the build system. Fixes #16 