### PR TITLE
[regtest] Get regtest solution to validate, default to 0 forkblocks

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -355,8 +355,8 @@ public:
 
         nPruneAfterHeight = 1000;
 
-        nEquihashN = 200;
-        nEquihashK = 9;
+        nEquihashN = 48;
+        nEquihashK = 5;
 
         uint256 nNonce = uint256S("0000000000000000000000000000000000000000000000000000000000000009");
         genesis = CreateGenesisBlock(1482971059, nNonce, 0x200f0f0f, 4, 0, GenesisSolutions::REGTEST);
@@ -392,8 +392,8 @@ public:
 
         m_fallback_fee_enabled = true;
 
-        nForkStartHeight = 10;
-        nForkHeightRange = 300;
+        nForkStartHeight = 0;
+        nForkHeightRange = 0;
     }
 };
 


### PR DESCRIPTION
Fixes the following failure of `./src/bitcoind -regtest`:
```
2018-07-28T22:06:12Z init message: Loading wallet...
2018-07-28T22:06:12Z nFileVersion = 169900
2018-07-28T22:06:12Z Keys: 2001 plaintext, 0 encrypted, 2001 w/ metadata, 2001 total. Unknown wallet records: 1
2018-07-28T22:06:12Z  wallet                   29ms
2018-07-28T22:06:12Z setKeyPool.size() = 2000
2018-07-28T22:06:12Z mapWallet.size() = 0
2018-07-28T22:06:12Z mapAddressBook.size() = 0
2018-07-28T22:06:12Z Reindexing block file blk00000.dat...
2018-07-28T22:06:12Z ERROR: CheckBlockHeader(): Equihash solution invalid
2018-07-28T22:06:12Z ERROR: AcceptBlock: invalid-solution (code 16)
2018-07-28T22:06:12Z Reindexing finished
2018-07-28T22:06:12Z Failed to open mempool file from disk. Continuing anyway.
```
