### PR TITLE
[wallet] Fix sendtoaddress - MutableTransactionSignatureCreator had wrong signature

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3045,7 +3045,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
                 const CScript& scriptPubKey = coin.txout.scriptPubKey;
                 SignatureData sigdata;
 
-                if (!ProduceSignature(*this, MutableTransactionSignatureCreator(&txNew, nIn, coin.txout.nValue, SIGHASH_ALL), scriptPubKey, sigdata))
+                if (!ProduceSignature(*this, MutableTransactionSignatureCreator(&txNew, nIn, coin.txout.nValue), scriptPubKey, sigdata))
                 {
                     strFailReason = _("Signing transaction failed");
                     return false;


### PR DESCRIPTION
(It needed to use `SIGHASH_ALL | SIGHASH_FORKID` internally)