### PR TITLE
[fixup] isForkEnabled

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1190,12 +1190,14 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
     CAmount nSubsidy = 12.5 * COIN;
 
     int halvingInterval = consensusParams.nSubsidyHalvingInterval;
-    if(isForkEnabled(nHeight)) {
+    uint64_t forkStartHeight = Params().ForkStartHeight();
+    
+    if(isForkEnabled(nHeight, forkStartHeight)) {
         halvingInterval >>= 2;
     }
 
     int halvings = nHeight / halvingInterval;
-    if(isForkEnabled(nHeight))
+    if(isForkEnabled(nHeight, forkStartHeight))
         halvings += 2;
 
     // Force block reward to zero when right shift is undefined.


### PR DESCRIPTION
```
dsktp@dsktp-VirtualBox:~/BTCP-Rebase$ make
Making all in src
make[1]: Entering directory '/home/dsktp/BTCP-Rebase/src'
make[2]: Entering directory '/home/dsktp/BTCP-Rebase/src'
make[3]: Entering directory '/home/dsktp/BTCP-Rebase'
make[3]: Leaving directory '/home/dsktp/BTCP-Rebase'
make[3]: Entering directory '/home/dsktp/BTCP-Rebase/src/secp256k1'
make[3]: Leaving directory '/home/dsktp/BTCP-Rebase/src/secp256k1'
  CXX      libbitcoin_server_a-validation.o
validation.cpp: In function ‘CAmount GetBlockSubsidy(int, const Consensus::Params&)’:
validation.cpp:1193:29: error: too few arguments to function ‘bool isForkEnabled(int, int)’
     if(isForkEnabled(nHeight)) {
                             ^
In file included from validation.cpp:18:0:
./fork.h:24:13: note: declared here
 inline bool isForkEnabled(int nHeight, int forkStartHeight)
             ^~~~~~~~~~~~~
validation.cpp:1198:29: error: too few arguments to function ‘bool isForkEnabled(int, int)’
     if(isForkEnabled(nHeight))
                             ^
In file included from validation.cpp:18:0:
./fork.h:24:13: note: declared here
 inline bool isForkEnabled(int nHeight, int forkStartHeight)
             ^~~~~~~~~~~~~
Makefile:6492: recipe for target 'libbitcoin_server_a-validation.o' failed
```

Please test + be cautious when merging pull requests:

The Linux build needs to never break, enforced by GH / Travis CI (Shoutout #19)