### PR TITLE
Revert "[tests] Fix .travis.yml repo ref"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ jobs:
         - test/lint/check-doc.py
         - test/lint/check-rpc-mappings.py .
         - test/lint/lint-all.sh
-        - if [ "$TRAVIS_REPO_SLUG" = "BTCPrivate/BTCP-Rebase" -a "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+        - if [ "$TRAVIS_REPO_SLUG" = "bitcoin/bitcoin" -a "$TRAVIS_EVENT_TYPE" = "cron" ]; then
               while read LINE; do travis_retry gpg --keyserver hkp://subset.pool.sks-keyservers.net --recv-keys $LINE; done < contrib/verify-commits/trusted-keys &&
               travis_wait 30 contrib/verify-commits/verify-commits.sh;
           fi


### PR DESCRIPTION
This reverts commit fbd96ae70da70d79d5843b617757812a00e99b17.

It actually broke, because the `.travis.yml` contains references to `/pulls/`:
```
$ cd BTCPrivate/BTCP-Rebase
3.53s$ git fetch origin +refs/pull/54/merge:
fatal: Couldn't find remote ref refs/pull/54/merge
The command "eval git fetch origin +refs/pull/54/merge: " failed. Retrying, 2 of 3.
fatal: Couldn't find remote ref refs/pull/54/merge
The command "eval git fetch origin +refs/pull/54/merge: " failed. Retrying, 3 of 3.
fatal: Couldn't find remote ref refs/pull/54/merge
The command "eval git fetch origin +refs/pull/54/merge: " failed 3 times.
```

Reverting to `bitcoin/bitcoin`, so they can continue being the maintainer for these modules. 

I just needed to read the original Travis output carefully:
```
$ test/lint/lint-all.sh
src/asyncrpcoperation.h seems to be missing the expected include guard:
  #ifndef BITCOIN_ASYNCRPCOPERATION_H
  #define BITCOIN_ASYNCRPCOPERATION_H
  ...
  #endif // BITCOIN_ASYNCRPCOPERATION_H
src/asyncrpcqueue.h seems to be missing the expected include guard:
  #ifndef BITCOIN_ASYNCRPCQUEUE_H
  #define BITCOIN_ASYNCRPCQUEUE_H
  ...
  #endif // BITCOIN_ASYNCRPCQUEUE_H
src/consensus/joinsplit.h seems to be missing the expected include guard:
  #ifndef BITCOIN_CONSENSUS_JOINSPLIT_H
  #define BITCOIN_CONSENSUS_JOINSPLIT_H
  ...
  #endif // BITCOIN_CONSENSUS_JOINSPLIT_H
src/crypto/equihash.h seems to be missing the expected include guard:
  #ifndef BITCOIN_CRYPTO_EQUIHASH_H
  #define BITCOIN_CRYPTO_EQUIHASH_H
  ...
  #endif // BITCOIN_CRYPTO_EQUIHASH_H
src/fork.h seems to be missing the expected include guard:
  #ifndef BITCOIN_FORK_H
  #define BITCOIN_FORK_H
  ...
  #endif // BITCOIN_FORK_H
src/gtest/json_test_vectors.h seems to be missing the expected include guard:
  #ifndef BITCOIN_GTEST_JSON_TEST_VECTORS_H
  #define BITCOIN_GTEST_JSON_TEST_VECTORS_H
  ...
  #endif // BITCOIN_GTEST_JSON_TEST_VECTORS_H
src/paymentdisclosure.h seems to be missing the expected include guard:
  #ifndef BITCOIN_PAYMENTDISCLOSURE_H
  #define BITCOIN_PAYMENTDISCLOSURE_H
  ...
  #endif // BITCOIN_PAYMENTDISCLOSURE_H
src/paymentdisclosuredb.h seems to be missing the expected include guard:
  #ifndef BITCOIN_PAYMENTDISCLOSUREDB_H
  #define BITCOIN_PAYMENTDISCLOSUREDB_H
  ...
  #endif // BITCOIN_PAYMENTDISCLOSUREDB_H
src/primitives/joinsplit.h seems to be missing the expected include guard:
  #ifndef BITCOIN_PRIMITIVES_JOINSPLIT_H
  #define BITCOIN_PRIMITIVES_JOINSPLIT_H
  ...
  #endif // BITCOIN_PRIMITIVES_JOINSPLIT_H
src/uint252.h seems to be missing the expected include guard:
  #ifndef BITCOIN_UINT252_H
  #define BITCOIN_UINT252_H
  ...
  #endif // BITCOIN_UINT252_H
src/wallet/asyncrpcoperation_mergetoaddress.h seems to be missing the expected include guard:
  #ifndef BITCOIN_WALLET_ASYNCRPCOPERATION_MERGETOADDRESS_H
  #define BITCOIN_WALLET_ASYNCRPCOPERATION_MERGETOADDRESS_H
  ...
  #endif // BITCOIN_WALLET_ASYNCRPCOPERATION_MERGETOADDRESS_H
src/wallet/asyncrpcoperation_sendmany.h seems to be missing the expected include guard:
  #ifndef BITCOIN_WALLET_ASYNCRPCOPERATION_SENDMANY_H
  #define BITCOIN_WALLET_ASYNCRPCOPERATION_SENDMANY_H
  ...
  #endif // BITCOIN_WALLET_ASYNCRPCOPERATION_SENDMANY_H
src/wallet/asyncrpcoperation_shieldcoinbase.h seems to be missing the expected include guard:
  #ifndef BITCOIN_WALLET_ASYNCRPCOPERATION_SHIELDCOINBASE_H
  #define BITCOIN_WALLET_ASYNCRPCOPERATION_SHIELDCOINBASE_H
  ...
  #endif // BITCOIN_WALLET_ASYNCRPCOPERATION_SHIELDCOINBASE_H
src/zcash/Zcash.h seems to be missing the expected include guard:
  #ifndef BITCOIN_ZCASH_ZCASH_H
  #define BITCOIN_ZCASH_ZCASH_H
  ...
  #endif // BITCOIN_ZCASH_ZCASH_H
src/zcash/prf.h seems to be missing the expected include guard:
  #ifndef BITCOIN_ZCASH_PRF_H
  #define BITCOIN_ZCASH_PRF_H
  ...
  #endif // BITCOIN_ZCASH_PRF_H
src/zcash/util.h seems to be missing the expected include guard:
  #ifndef BITCOIN_ZCASH_UTIL_H
  #define BITCOIN_ZCASH_UTIL_H
  ...
  #endif // BITCOIN_ZCASH_UTIL_H
^---- failure generated from test/lint/lint-include-guards.sh
```

This is the real target issue to fix.