### PR TITLE
[wallet] Add SIGHASH_FORKID where necessary

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -633,7 +633,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
 
     const CKeyStore& keystore = tempKeystore;
 
-    bool fHashSingle = ((nHashType & ~SIGHASH_ANYONECANPAY) == SIGHASH_SINGLE);
+    bool fHashSingle = ((nHashType & ~(SIGHASH_ANYONECANPAY|SIGHASH_FORKID)) == SIGHASH_SINGLE);
 
     // Sign what we can:
     for (unsigned int i = 0; i < mergedTx.vin.size(); i++) {

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -62,12 +62,12 @@ std::string FormatScript(const CScript& script)
 }
 
 const std::map<unsigned char, std::string> mapSigHashTypes = {
-    {static_cast<unsigned char>(SIGHASH_ALL), std::string("ALL")},
-    {static_cast<unsigned char>(SIGHASH_ALL|SIGHASH_ANYONECANPAY), std::string("ALL|ANYONECANPAY")},
-    {static_cast<unsigned char>(SIGHASH_NONE), std::string("NONE")},
-    {static_cast<unsigned char>(SIGHASH_NONE|SIGHASH_ANYONECANPAY), std::string("NONE|ANYONECANPAY")},
-    {static_cast<unsigned char>(SIGHASH_SINGLE), std::string("SINGLE")},
-    {static_cast<unsigned char>(SIGHASH_SINGLE|SIGHASH_ANYONECANPAY), std::string("SINGLE|ANYONECANPAY")},
+    {static_cast<unsigned char>(SIGHASH_ALL|SIGHASH_FORKID), std::string("ALL|FORKID")},
+    {static_cast<unsigned char>(SIGHASH_ALL|SIGHASH_ANYONECANPAY|SIGHASH_FORKID), std::string("ALL|ANYONECANPAY|FORKID")},
+    {static_cast<unsigned char>(SIGHASH_NONE|SIGHASH_FORKID), std::string("NONE|FORKID")},
+    {static_cast<unsigned char>(SIGHASH_NONE|SIGHASH_ANYONECANPAY|SIGHASH_FORKID), std::string("NONE|ANYONECANPAY|FORKID")},
+    {static_cast<unsigned char>(SIGHASH_SINGLE|SIGHASH_FORKID), std::string("SINGLE|FORKID")},
+    {static_cast<unsigned char>(SIGHASH_SINGLE|SIGHASH_ANYONECANPAY|SIGHASH_FORKID), std::string("SINGLE|ANYONECANPAY|FORKID")},
 };
 
 /**

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -838,15 +838,15 @@ UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxsUnival
         }
     }
 
-    int nHashType = SIGHASH_ALL;
+    int nHashType = SIGHASH_ALL | SIGHASH_FORKID;
     if (!hashType.isNull()) {
         static std::map<std::string, int> mapSigHashValues = {
-            {std::string("ALL"), int(SIGHASH_ALL)},
-            {std::string("ALL|ANYONECANPAY"), int(SIGHASH_ALL|SIGHASH_ANYONECANPAY)},
-            {std::string("NONE"), int(SIGHASH_NONE)},
-            {std::string("NONE|ANYONECANPAY"), int(SIGHASH_NONE|SIGHASH_ANYONECANPAY)},
-            {std::string("SINGLE"), int(SIGHASH_SINGLE)},
-            {std::string("SINGLE|ANYONECANPAY"), int(SIGHASH_SINGLE|SIGHASH_ANYONECANPAY)},
+            {std::string("ALL|FORKID"), int(SIGHASH_ALL|SIGHASH_FORKID)},
+            {std::string("ALL|ANYONECANPAY|FORKID"), int(SIGHASH_ALL|SIGHASH_ANYONECANPAY|SIGHASH_FORKID)},
+            {std::string("NONE|FORKID"), int(SIGHASH_NONE|SIGHASH_FORKID)},
+            {std::string("NONE|ANYONECANPAY|FORKID"), int(SIGHASH_NONE|SIGHASH_ANYONECANPAY|SIGHASH_FORKID)},
+            {std::string("SINGLE|FORKID"), int(SIGHASH_SINGLE|SIGHASH_FORKID)},
+            {std::string("SINGLE|ANYONECANPAY|FORKID"), int(SIGHASH_SINGLE|SIGHASH_ANYONECANPAY|SIGHASH_FORKID)},
         };
         std::string strHashType = hashType.get_str();
         if (mapSigHashValues.count(strHashType)) {
@@ -856,7 +856,7 @@ UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxsUnival
         }
     }
 
-    bool fHashSingle = ((nHashType & ~SIGHASH_ANYONECANPAY) == SIGHASH_SINGLE);
+    bool fHashSingle = ((nHashType & ~(SIGHASH_ANYONECANPAY|SIGHASH_FORKID)) == SIGHASH_SINGLE);
 
     // Script verification errors
     UniValue vErrors(UniValue::VARR);

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -45,7 +45,7 @@ class MutableTransactionSignatureCreator : public BaseSignatureCreator {
     const MutableTransactionSignatureChecker checker;
 
 public:
-    MutableTransactionSignatureCreator(const CMutableTransaction* txToIn, unsigned int nInIn, const CAmount& amountIn, int nHashTypeIn = SIGHASH_ALL|SIGHASH_FORKID);
+    MutableTransactionSignatureCreator(const CMutableTransaction* txToIn, unsigned int nInIn, const CAmount& amountIn, int nHashTypeIn = SIGHASH_ALL | SIGHASH_FORKID);
     const BaseSignatureChecker& Checker() const override { return checker; }
     bool CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const override;
 };


### PR DESCRIPTION
Allows raw transaction signing to succeed; before it would error:
```
➜ ./src/bitcoin-cli -regtest signrawtransaction 02000000015736f443fbe0d0fc1156f32e65407e0dc02f58e3371bd73daff092b09dd931e00000000000ffffffff01c0b99d0600000000160014e421a4a76ede53bf06bbb84df400f74de86e5e6b0000000000    
{
  "hex": "02000000015736f443fbe0d0fc1156f32e65407e0dc02f58e3371bd73daff092b09dd931e000000000494830450221009303916f77999d2a0dad64de7b41abf9c517e24888b5030d5669734a315dbfbf022016583c480eda04b6a3e13077959384e873be7e98a5aac6a3e3fdce7314209cb501ffffffff01c0b99d0600000000160014e421a4a76ede53bf06bbb84df400f74de86e5e6b0000000000",
  "complete": false,
  "errors": [
    {
      "txid": "e031d99db092f0af3dd71b37e3582fc00d7e40652ef35611fcd0e0fb43f43657",
      "vout": 0,
      "witness": [
      ],
      "scriptSig": "4830450221009303916f77999d2a0dad64de7b41abf9c517e24888b5030d5669734a315dbfbf022016583c480eda04b6a3e13077959384e873be7e98a5aac6a3e3fdce7314209cb501",
      "sequence": 4294967295,
      "error": "Signature hash type missing or not understood"
    }
  ]
}
```