### PR TITLE
Activate BIP34 for testnet and regtest

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -215,7 +215,7 @@ public:
         consensus.nSubsidyHalvingInterval = 840000;
 
         // P2SH, height in coinbase, CLTV and DERSIG all enforced from genesis
-        consensus.BIP34Height = 0;
+        consensus.BIP34Height = 17;
         consensus.BIP65Height = 0;
         consensus.BIP66Height = 0;
 
@@ -320,7 +320,7 @@ public:
         consensus.nSubsidyHalvingInterval = 840000;
 
         // P2SH, height in coinbase, CLTV and DERSIG all enforced from genesis
-        consensus.BIP34Height = 0;
+        consensus.BIP34Height = 17;
         consensus.BIP65Height = 0;
         consensus.BIP66Height = 0;
 


### PR DESCRIPTION
Activate BIP34 at block 17 for test networks, the smallest value possibly for a CScriptNum to be represented as expected